### PR TITLE
Add configuration module with env validation

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,0 +1,26 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+const requiredVars = ['FS_BASE', 'FS_USER', 'FS_CODE'];
+for (const v of requiredVars) {
+  if (!process.env[v]) {
+    throw new Error(`Missing required environment variable ${v}`);
+  }
+}
+
+function intFromEnv(name, defaultValue) {
+  const value = process.env[name];
+  return value ? parseInt(value, 10) : defaultValue;
+}
+
+module.exports = {
+  FS_BASE: process.env.FS_BASE,
+  FS_USER: process.env.FS_USER,
+  FS_CODE: process.env.FS_CODE,
+  MA_PROXY: process.env.MA_PROXY,
+  LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+  FRONTEND_ORIGIN: process.env.FRONTEND_ORIGIN || '*',
+  PORT: intFromEnv('PORT', 8081),
+  CACHE_TTL_SECONDS: intFromEnv('CACHE_TTL_SECONDS', 90),
+  GIT_SHA: process.env.GIT_SHA,
+};

--- a/backend/lib/fusionsolarClient.js
+++ b/backend/lib/fusionsolarClient.js
@@ -4,11 +4,13 @@ const tough = require('tough-cookie');
 const { wrapper } = require('axios-cookiejar-support');
 const NodeCache = require('node-cache');
 
-const FS_BASE = process.env.FS_BASE;
-const FS_USER = process.env.FS_USER;
-const FS_CODE = process.env.FS_CODE;
-const MA_PROXY = process.env.MA_PROXY;
-const CACHE_TTL = parseInt(process.env.CACHE_TTL_SECONDS || '90', 10);
+const {
+  FS_BASE,
+  FS_USER,
+  FS_CODE,
+  MA_PROXY,
+  CACHE_TTL_SECONDS: CACHE_TTL,
+} = require('../config');
 
 class FusionSolarClient {
   constructor() {

--- a/backend/test/config.test.js
+++ b/backend/test/config.test.js
@@ -1,0 +1,23 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const serverPath = path.join(__dirname, '..', 'server.js');
+
+const baseEnv = {
+  ...process.env,
+  FS_BASE: 'https://example.com',
+  FS_USER: 'user',
+  FS_CODE: 'code',
+};
+
+describe('server configuration', () => {
+  ['FS_BASE', 'FS_USER', 'FS_CODE'].forEach((variable) => {
+    test(`fails fast when ${variable} is missing`, () => {
+      const env = { ...baseEnv };
+      delete env[variable];
+      const result = spawnSync('node', [serverPath], { env, encoding: 'utf8' });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Missing required environment variable ${variable}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- centralize environment loading in `backend/config.js` and validate required variables
- ensure `server.js` fails fast on missing configuration and use centralized config
- use config inside FusionSolar client and add unit tests for missing env vars

## Testing
- `npm test --prefix backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a66369696c8324ba8b5367fee599e0