### PR TITLE
Add API endpoint tests for station data and health check

### DIFF
--- a/backend/test/alarms.test.js
+++ b/backend/test/alarms.test.js
@@ -1,0 +1,39 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../server');
+
+describe('GET /api/stations/:code/alarms', () => {
+  afterEach(() => nock.cleanAll());
+
+  it('returns station alarms', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/alarmList', { stationCodes: '1', severity: '1' })
+      .reply(200, { data: { list: [{ alarmId: 'a1' }] } });
+
+    const res = await request(app).get('/api/stations/1/alarms?severity=1');
+    expect(res.status).toBe(200);
+    expect(res.body.data.list[0].alarmId).toBe('a1');
+  });
+
+  it('handles invalid parameters', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/alarmList', { stationCodes: '1', severity: 'bad' })
+      .reply(400, { error: 'invalid' });
+
+    const res = await request(app).get('/api/stations/1/alarms?severity=bad');
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('upstream_error');
+  });
+});

--- a/backend/test/devices.test.js
+++ b/backend/test/devices.test.js
@@ -1,0 +1,39 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../server');
+
+describe('GET /api/stations/:code/devices', () => {
+  afterEach(() => nock.cleanAll());
+
+  it('returns station devices', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/deviceList', { stationCodes: '1' })
+      .reply(200, { data: { list: [{ deviceName: 'INV1' }] } });
+
+    const res = await request(app).get('/api/stations/1/devices');
+    expect(res.status).toBe(200);
+    expect(res.body.data.list[0].deviceName).toBe('INV1');
+  });
+
+  it('handles upstream error', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/deviceList', { stationCodes: '1' })
+      .reply(500);
+
+    const res = await request(app).get('/api/stations/1/devices');
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('upstream_error');
+  });
+});

--- a/backend/test/health.test.js
+++ b/backend/test/health.test.js
@@ -1,0 +1,38 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../server');
+const net = require('net');
+const { EventEmitter } = require('events');
+
+describe('GET /healthz', () => {
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+    delete process.env.MA_PROXY;
+  });
+
+  it('reports healthy status', async () => {
+    const res = await request(app).get('/healthz');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.proxyReachable).toBe(true);
+  });
+
+  it('reports proxy unreachable', async () => {
+    process.env.MA_PROXY = 'http://127.0.0.1:1234';
+    jest.spyOn(net, 'createConnection').mockImplementation(() => {
+      const socket = new EventEmitter();
+      socket.setTimeout = () => {};
+      socket.destroy = () => {};
+      process.nextTick(() => socket.emit('error', new Error('fail')));
+      return socket;
+    });
+    const res = await request(app).get('/healthz');
+    expect(res.status).toBe(200);
+    expect(res.body.proxyReachable).toBe(false);
+  });
+});

--- a/backend/test/overview.test.js
+++ b/backend/test/overview.test.js
@@ -1,0 +1,35 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../server');
+
+describe('GET /api/stations/:code/overview', () => {
+  afterEach(() => nock.cleanAll());
+
+  it('returns station overview', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/stationRealKpi', { stationCodes: '1' })
+      .reply(200, { data: { stationCode: '1', stationName: 'A' } });
+
+    const res = await request(app).get('/api/stations/1/overview');
+    expect(res.status).toBe(200);
+    expect(res.body.data.stationName).toBe('A');
+  });
+
+  it('handles login failure', async () => {
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .reply(500);
+
+    const res = await request(app).get('/api/stations/1/overview');
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('upstream_error');
+  });
+});


### PR DESCRIPTION
## Summary
- add station overview tests with login failure handling
- cover device listing including upstream error path
- add alarm listing tests with invalid parameter case
- test health check for proxy availability

## Testing
- `npm test --prefix backend` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a663888a008324a9ceaf8dd4940320