### PR TITLE
feat(frontend): centralize API base handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ npm test --prefix backend
 - `.env.example` – environment variables.
 - `docker-compose.yml` – run backend and frontend together.
 
+## Frontend API base
+
+The frontend builds all API requests using the helper in `frontend/lib/api.js`, which
+prefixes paths with `NEXT_PUBLIC_API_BASE`. Set this environment variable to the
+backend's base path (e.g., `/api`).
+
 ## Proxy
 
 All outbound FusionSolar traffic is routed through the proxy defined in `MA_PROXY`.

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,0 +1,7 @@
+export const apiFetch = (path, options) => {
+  const base = process.env.NEXT_PUBLIC_API_BASE || '';
+  return fetch(`${base}${path}`, options);
+};
+
+export const fetcher = (path, options) =>
+  apiFetch(path, options).then(res => res.json());

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,9 +1,8 @@
 import useSWR from 'swr';
-
-const fetcher = url => fetch(url).then(r => r.json());
+import { fetcher } from '../lib/api';
 
 export default function Home() {
-  const { data, error } = useSWR('/api/stations', fetcher, { refreshInterval: 60000 });
+  const { data, error } = useSWR('/stations', fetcher, { refreshInterval: 60000 });
 
   if (error) return <div>Error loading stations.</div>;
   if (!data) return <div>Loading...</div>;

--- a/frontend/pages/stations/[code].js
+++ b/frontend/pages/stations/[code].js
@@ -1,12 +1,15 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
-
-const fetcher = url => fetch(url).then(r => r.json());
+import { fetcher } from '../../lib/api';
 
 export default function StationDetail() {
   const router = useRouter();
   const { code } = router.query;
-  const { data, error } = useSWR(() => code ? `/api/stations/${code}/overview` : null, fetcher, { refreshInterval: 60000 });
+  const { data, error } = useSWR(
+    () => (code ? `/stations/${code}/overview` : null),
+    fetcher,
+    { refreshInterval: 60000 }
+  );
 
   if (error) return <div>Error loading station.</div>;
   if (!data) return <div>Loading...</div>;


### PR DESCRIPTION
## Summary
- add helper to prefix API paths with `NEXT_PUBLIC_API_BASE`
- refactor pages to use shared fetch helper
- document `NEXT_PUBLIC_API_BASE` usage

## Testing
- `npm install --prefix backend` *(fails: No matching version found for axios-cookiejar-support@^2.1.5)*
- `npm test --prefix backend` *(fails: jest: not found)*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_68a66383756483248a7551b2824d20a0