### PR TITLE
Add login mutex to FusionSolar client

### DIFF
--- a/backend/lib/fusionsolarClient.js
+++ b/backend/lib/fusionsolarClient.js
@@ -22,14 +22,22 @@ class FusionSolarClient {
     }));
     this.cache = new NodeCache({ stdTTL: CACHE_TTL });
     this.loggedIn = false;
+    this.loginPromise = null;
   }
 
   async login() {
-    await this.client.post('/thirdData/login', {
-      userName: FS_USER,
-      systemCode: FS_CODE,
-    });
-    this.loggedIn = true;
+    if (!this.loginPromise) {
+      this.loginPromise = (async () => {
+        await this.client.post('/thirdData/login', {
+          userName: FS_USER,
+          systemCode: FS_CODE,
+        });
+        this.loggedIn = true;
+      })().finally(() => {
+        this.loginPromise = null;
+      });
+    }
+    return this.loginPromise;
   }
 
   async ensureLogin() {

--- a/backend/test/login-lock.test.js
+++ b/backend/test/login-lock.test.js
@@ -1,0 +1,50 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const nock = require('nock');
+const FusionSolarClient = require('../lib/fusionsolarClient');
+
+describe('FusionSolarClient login locking', () => {
+  afterEach(() => nock.cleanAll());
+
+  it('reuses in-flight login for concurrent ensureLogin calls', async () => {
+    const client = new FusionSolarClient();
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .times(1)
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    await Promise.all([
+      client.ensureLogin(),
+      client.ensureLogin(),
+      client.ensureLogin(),
+    ]);
+
+    expect(client.loggedIn).toBe(true);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('logs in once when multiple requests run concurrently', async () => {
+    const client = new FusionSolarClient();
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/login')
+      .times(1)
+      .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
+
+    nock(process.env.FS_BASE)
+      .post('/thirdData/stationList')
+      .times(3)
+      .reply(200, { data: { list: [] } });
+
+    await Promise.all([
+      client.stationList(),
+      client.stationList(),
+      client.stationList(),
+    ]);
+
+    expect(nock.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent duplicate login requests by tracking a shared login promise in `FusionSolarClient`
- add tests to verify concurrent calls reuse the same in-flight login

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: No matching version found for axios-cookiejar-support@^2.1.5)*

------
https://chatgpt.com/codex/tasks/task_b_68a6637ceaf08324a1dc1e04c4ebdba7