### PR TITLE
Add request validation for stations and alarms

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-validator": "^6.15.0",
     "https-proxy-agent": "^5.0.1",
     "node-cache": "^5.1.2",
     "pino": "^8.15.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const pino = require('pino');
 const pinoHttp = require('pino-http');
+const { query, validationResult } = require('express-validator');
 const FusionSolarClient = require('./lib/fusionsolarClient');
 
 const app = express();
@@ -13,17 +14,33 @@ app.use(cors({ origin: process.env.FRONTEND_ORIGIN || '*' }));
 
 const client = new FusionSolarClient();
 
-app.get('/api/stations', async (req, res) => {
-  try {
-    const pageNo = Number(req.query.pageNo || 1);
-    const pageSize = Number(req.query.pageSize || 20);
-    const data = await client.stationList(pageNo, pageSize);
-    res.json(data);
-  } catch (err) {
-    logger.error({ err }, 'stationList failed');
-    res.status(502).json({ error: 'upstream_error' });
+function handleValidationErrors(req, res, next) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array().map(e => e.msg) });
   }
-});
+  next();
+}
+
+app.get(
+  '/api/stations',
+  [
+    query('pageNo').optional().isInt({ min: 1 }).withMessage('pageNo must be a positive integer').toInt(),
+    query('pageSize').optional().isInt({ min: 1 }).withMessage('pageSize must be a positive integer').toInt(),
+  ],
+  handleValidationErrors,
+  async (req, res) => {
+    try {
+      const pageNo = req.query.pageNo || 1;
+      const pageSize = req.query.pageSize || 20;
+      const data = await client.stationList(pageNo, pageSize);
+      res.json(data);
+    } catch (err) {
+      logger.error({ err }, 'stationList failed');
+      res.status(502).json({ error: 'upstream_error' });
+    }
+  }
+);
 
 app.get('/api/stations/:code/overview', async (req, res) => {
   try {
@@ -45,15 +62,26 @@ app.get('/api/stations/:code/devices', async (req, res) => {
   }
 });
 
-app.get('/api/stations/:code/alarms', async (req, res) => {
-  try {
-    const data = await client.stationAlarms(req.params.code, req.query.severity);
-    res.json(data);
-  } catch (err) {
-    logger.error({ err }, 'stationAlarms failed');
-    res.status(502).json({ error: 'upstream_error' });
+app.get(
+  '/api/stations/:code/alarms',
+  [
+    query('severity')
+      .optional()
+      .isInt({ min: 1, max: 4 })
+      .withMessage('severity must be an integer between 1 and 4')
+      .toInt(),
+  ],
+  handleValidationErrors,
+  async (req, res) => {
+    try {
+      const data = await client.stationAlarms(req.params.code, req.query.severity);
+      res.json(data);
+    } catch (err) {
+      logger.error({ err }, 'stationAlarms failed');
+      res.status(502).json({ error: 'upstream_error' });
+    }
   }
-});
+);
 
 app.get('/healthz', async (req, res) => {
   const net = require('net');

--- a/backend/test/alarms.test.js
+++ b/backend/test/alarms.test.js
@@ -1,0 +1,15 @@
+process.env.FS_USER = 'test';
+process.env.FS_CODE = 'test';
+process.env.FS_BASE = 'https://intl.fusionsolar.huawei.com';
+
+const request = require('supertest');
+const app = require('../server');
+
+describe('GET /api/stations/:code/alarms', () => {
+  it('returns 400 for invalid severity', async () => {
+    const res = await request(app).get('/api/stations/1/alarms?severity=5');
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toContain('severity must be an integer between 1 and 4');
+  });
+});
+

--- a/backend/test/stations.test.js
+++ b/backend/test/stations.test.js
@@ -22,4 +22,11 @@ describe('GET /api/stations', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.list[0].stationName).toBe('A');
   });
+
+  it('returns 400 for invalid pagination', async () => {
+    const res = await request(app).get('/api/stations?pageNo=0&pageSize=-1');
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toContain('pageNo must be a positive integer');
+    expect(res.body.errors).toContain('pageSize must be a positive integer');
+  });
 });


### PR DESCRIPTION
## Summary
- use express-validator to enforce positive page pagination and allowed alarm severities
- handle validation errors with 400 responses
- cover invalid parameter cases with tests

## Testing
- `npm install express-validator@^6.15.0 --no-package-lock` *(fails: No matching version found / 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a66377ca1483249ebd86a35d445df9