### PR TITLE
Update FusionSolar client NB endpoints and alarm body

### DIFF
--- a/backend/lib/fusionsolarClient.js
+++ b/backend/lib/fusionsolarClient.js
@@ -96,19 +96,28 @@ class FusionSolarClient {
   }
 
   stationList(pageNo = 1, pageSize = 20) {
-    return this.request('POST', '/thirdData/stationList', { data: { pageNo, pageSize } }, `stationList-${pageNo}-${pageSize}`);
+    return this.request('POST', '/thirdData/stations', { data: { pageNo, pageSize } }, `stationList-${pageNo}-${pageSize}`);
   }
 
   stationOverview(code) {
-    return this.request('POST', '/thirdData/stationRealKpi', { data: { stationCodes: code } }, `overview-${code}`);
+    return this.request('POST', '/thirdData/getStationRealKpi', { data: { stationCodes: code } }, `overview-${code}`);
   }
 
   stationDevices(code) {
-    return this.request('POST', '/thirdData/deviceList', { data: { stationCodes: code } }, `devices-${code}`);
+    return this.request('POST', '/thirdData/getDevList', { data: { stationCodes: code } }, `devices-${code}`);
   }
 
   stationAlarms(code, severity) {
-    return this.request('POST', '/thirdData/alarmList', { data: { stationCodes: code, severity } }, `alarms-${code}-${severity || 'all'}`);
+    const now = Date.now();
+    const dayAgo = now - 24 * 60 * 60 * 1000;
+    const data = {
+      stationCodes: code,
+      severity,
+      beginTime: dayAgo,
+      endTime: now,
+      language: 'en_US',
+    };
+    return this.request('POST', '/thirdData/getAlarmList', { data }, `alarms-${code}-${severity || 'all'}`);
   }
 }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -105,7 +105,7 @@ app.get('/healthz', async (req, res) => {
   if (process.env.MA_PROXY) {
     try {
       const agent = new HttpsProxyAgent(process.env.MA_PROXY);
-      await axios.head('https://example.com', { httpsAgent: agent, timeout: 5000 });
+      await axios.head('https://ifconfig.me', { httpsAgent: agent, timeout: 5000 });
       proxyReachable = true;
     } catch (e) {
       proxyReachable = false;

--- a/backend/test/devices.test.js
+++ b/backend/test/devices.test.js
@@ -14,7 +14,7 @@ describe('GET /api/stations/:code/devices', () => {
       .post('/thirdData/login')
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
     nock(process.env.FS_BASE)
-      .post('/thirdData/deviceList')
+      .post('/thirdData/getDevList')
       .reply(200, { data: { list: [{ id: '1' }] } });
 
     const res = await request(app).get('/api/stations/1/devices');

--- a/backend/test/fusionsolarClient.test.js
+++ b/backend/test/fusionsolarClient.test.js
@@ -19,9 +19,9 @@ describe('FusionSolarClient', () => {
       .post('/thirdData/login')
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
     nock(process.env.FS_BASE)
-      .post('/thirdData/stationList')
+      .post('/thirdData/stations')
       .reply(500)
-      .post('/thirdData/stationList')
+      .post('/thirdData/stations')
       .reply(200, { data: { list: [] } });
 
     const data = await client.stationList();
@@ -40,7 +40,7 @@ describe('FusionSolarClient', () => {
       .post('/thirdData/login')
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
     nock(process.env.FS_BASE)
-      .post('/thirdData/stationRealKpi')
+      .post('/thirdData/getStationRealKpi')
       .reply(200, { data: { currentPower: 1, todayEnergy: 2, totalEnergy: 3 } });
 
     await client.stationOverview('1');
@@ -59,9 +59,9 @@ describe('FusionSolarClient', () => {
       .twice()
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
     nock(process.env.FS_BASE)
-      .post('/thirdData/stationList')
+      .post('/thirdData/stations')
       .reply(401, { msg: 'USER_MUST_RELOGIN' })
-      .post('/thirdData/stationList')
+      .post('/thirdData/stations')
       .reply(200, { data: { list: [1] } });
 
     const data = await client.stationList();

--- a/backend/test/overview.test.js
+++ b/backend/test/overview.test.js
@@ -14,7 +14,7 @@ describe('GET /api/stations/:code/overview', () => {
       .post('/thirdData/login')
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
     nock(process.env.FS_BASE)
-      .post('/thirdData/stationRealKpi')
+      .post('/thirdData/getStationRealKpi')
       .reply(200, { data: { realTimePower: 5, dayEnergy: 10, totalEnergy: 100 } });
 
     const res = await request(app).get('/api/stations/1/overview');

--- a/backend/test/stations.test.js
+++ b/backend/test/stations.test.js
@@ -15,7 +15,7 @@ describe('GET /api/stations', () => {
       .reply(200, { data: 'ok' }, { 'set-cookie': ['XSRF-TOKEN=abc'] });
 
     nock(process.env.FS_BASE)
-      .post('/thirdData/stationList')
+      .post('/thirdData/stations')
       .reply(200, { data: { list: [{ stationCode: '1', stationName: 'A' }] } });
 
     const res = await request(app).get('/api/stations');

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -58,6 +58,66 @@
           "path": ["healthz"]
         }
       }
+    },
+    {
+      "name": "FS Stations",
+      "request": {
+        "method": "POST",
+        "url": {
+          "raw": "{{fsBase}}/thirdData/stations",
+          "host": ["{{fsBase}}"],
+          "path": ["thirdData", "stations"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"pageNo\": 1,\n  \"pageSize\": 20\n}"
+        }
+      }
+    },
+    {
+      "name": "FS Station KPI",
+      "request": {
+        "method": "POST",
+        "url": {
+          "raw": "{{fsBase}}/thirdData/getStationRealKpi",
+          "host": ["{{fsBase}}"],
+          "path": ["thirdData", "getStationRealKpi"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"stationCodes\": \"XXXX\"\n}"
+        }
+      }
+    },
+    {
+      "name": "FS Device List",
+      "request": {
+        "method": "POST",
+        "url": {
+          "raw": "{{fsBase}}/thirdData/getDevList",
+          "host": ["{{fsBase}}"],
+          "path": ["thirdData", "getDevList"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"stationCodes\": \"XXXX\"\n}"
+        }
+      }
+    },
+    {
+      "name": "FS Alarm List",
+      "request": {
+        "method": "POST",
+        "url": {
+          "raw": "{{fsBase}}/thirdData/getAlarmList",
+          "host": ["{{fsBase}}"],
+          "path": ["thirdData", "getAlarmList"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"stationCodes\": \"XXXX\",\n  \"beginTime\": 0,\n  \"endTime\": 0,\n  \"language\": \"en_US\"\n}"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update FusionSolar client to use new NB endpoints and include alarm list defaults
- send proxy health checks via ifconfig.me and expand Postman collection
- refresh backend tests for new NB endpoints and required alarm params

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm install --prefix backend` *(fails: No matching version found for axios-cookiejar-support@^2.1.5)*

------
https://chatgpt.com/codex/tasks/task_b_68a7c589c44c832482a8231bccedaa26