### PR TITLE
Add FTP-friendly FusionSolar dashboard scaffold

### DIFF
--- a/app/README.txt
+++ b/app/README.txt
@@ -1,0 +1,25 @@
+SUNQ FusionSolar Dashboard
+===========================
+
+Setup
+-----
+1. Upload the entire `app` folder to your web host via FTP.
+2. Edit `app/config/.env.php` and fill in:
+   - `FS_USER` and `FS_CODE` with FusionSolar credentials.
+   - `ALLOWED_ORIGIN` with your domain.
+3. Set permissions:
+   - `app/storage` directory writable by the web server.
+   - `app/storage/cookies.txt` should have chmod 600.
+4. Access the app at `https://yourdomain.tld/app/public/index.html`.
+
+Configuration
+-------------
+- Logos: replace files in `app/public/assets/` (`client-logo.svg`, `sunq-logo.svg`).
+- Brand color: edit `--brand-color` in `app/public/assets/styles.css`.
+- Green metrics factors are defined in `app/public/index.html` near the top JS block.
+
+Quick Tests
+-----------
+Run from your browser or terminal:
+- `curl https://yourdomain.tld/app/api/healthz.php`
+- `curl https://yourdomain.tld/app/api/stations.php`

--- a/app/TEST_SCRIPT.txt
+++ b/app/TEST_SCRIPT.txt
@@ -1,0 +1,16 @@
+Manual Verification Script
+==========================
+
+1. Ensure credentials in `app/config/.env.php` are correct.
+2. From terminal, run:
+   - `curl https://yourdomain.tld/app/api/healthz.php`
+   - `curl https://yourdomain.tld/app/api/stations.php`
+   Both should return JSON with `ok:true`.
+3. Open `https://yourdomain.tld/app/public/index.html` in a browser.
+   - Stations list should load within a few seconds.
+4. Click a station to view details.
+   - KPI cards show current power, today energy, lifetime energy.
+   - Devices table lists inverters/meters.
+   - Alarms table lists active alarms.
+5. Wait 60s and confirm data refreshes (Last updated time changes).
+6. Toggle light/dark mode and ensure preference persists after reload.

--- a/app/api/_cache.php
+++ b/app/api/_cache.php
@@ -1,0 +1,29 @@
+<?php
+// Simple file-based cache
+require_once __DIR__ . '/_util.php';
+
+function cache_path($key) {
+    return __DIR__ . '/../storage/cache/' . md5($key) . '.json';
+}
+
+function cache_get($key) {
+    global $CONFIG;
+    if ($CONFIG['APP_ENV'] === 'dev' && isset($_GET['nocache'])) {
+        return null;
+    }
+    $file = cache_path($key);
+    if (!file_exists($file)) {
+        return null;
+    }
+    $ttl = $CONFIG['CACHE_TTL_SECONDS'];
+    if (filemtime($file) + $ttl < time()) {
+        return null;
+    }
+    $data = json_decode(file_get_contents($file), true);
+    return $data;
+}
+
+function cache_set($key, $data) {
+    $file = cache_path($key);
+    file_put_contents($file, json_encode($data));
+}

--- a/app/api/_client.php
+++ b/app/api/_client.php
@@ -1,0 +1,101 @@
+<?php
+// FusionSolar HTTP helper: cURL + proxy + cookie jar + XSRF
+require_once __DIR__ . '/_util.php';
+
+function fs_cookie_file() {
+    return __DIR__ . '/../storage/cookies.txt';
+}
+
+function fs_get_xsrf() {
+    $file = fs_cookie_file();
+    if (!file_exists($file)) {
+        return null;
+    }
+    $lines = file($file);
+    foreach ($lines as $line) {
+        if (strpos($line, 'XSRF-TOKEN') !== false) {
+            $parts = explode("\t", trim($line));
+            return end($parts);
+        }
+    }
+    return null;
+}
+
+function fs_login($force = false) {
+    global $CONFIG;
+    if (!$force && fs_get_xsrf()) {
+        return;
+    }
+    $payload = [
+        'userName' => $CONFIG['FS_USER'],
+        'systemCode' => $CONFIG['FS_CODE'],
+    ];
+    $url = rtrim($CONFIG['FS_BASE'], '/') . '/thirdData/login';
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => json_encode($payload),
+        CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+        CURLOPT_PROXY => $CONFIG['MA_PROXY'],
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_TIMEOUT => 20,
+        CURLOPT_COOKIEJAR => fs_cookie_file(),
+        CURLOPT_COOKIEFILE => fs_cookie_file(),
+    ]);
+    $res = curl_exec($ch);
+    if ($res === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new Exception('Login failed');
+    }
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($code !== 200) {
+        throw new Exception('Login failed');
+    }
+}
+
+function fs_request($method, $path, $payload = null, $query = []) {
+    global $CONFIG;
+    fs_login();
+    $url = rtrim($CONFIG['FS_BASE'], '/') . $path;
+    if ($query) {
+        $url .= '?' . http_build_query($query);
+    }
+    $headers = ['Content-Type: application/json'];
+    if ($token = fs_get_xsrf()) {
+        $headers[] = 'XSRF-TOKEN: ' . trim($token);
+    }
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_CUSTOMREQUEST => $method,
+        CURLOPT_PROXY => $CONFIG['MA_PROXY'],
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_TIMEOUT => 20,
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_COOKIEJAR => fs_cookie_file(),
+        CURLOPT_COOKIEFILE => fs_cookie_file(),
+    ]);
+    if ($payload) {
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+    }
+    $res = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $err = curl_error($ch);
+    curl_close($ch);
+    if ($res === false) {
+        throw new Exception('Request error');
+    }
+    if ($code == 401 || strpos($res, 'USER_MUST_RELOGIN') !== false) {
+        fs_login(true);
+        return fs_request($method, $path, $payload, $query);
+    }
+    if ($code >= 500 && $code < 600) {
+        // retry once on server error
+        usleep(100000);
+        return fs_request($method, $path, $payload, $query);
+    }
+    return json_decode($res, true);
+}

--- a/app/api/_util.php
+++ b/app/api/_util.php
@@ -1,0 +1,34 @@
+<?php
+// Common utilities: config loader, JSON helpers, logging, CORS
+
+$CONFIG = require __DIR__ . '/../config/.env.php';
+
+// Send CORS and JSON headers
+function send_headers() {
+    global $CONFIG;
+    header('Content-Type: application/json');
+    header('Access-Control-Allow-Origin: ' . $CONFIG['ALLOWED_ORIGIN']);
+    header('Vary: Origin');
+}
+
+// Successful JSON response
+function json_ok($data) {
+    send_headers();
+    echo json_encode(['ok' => true, 'data' => $data]);
+    exit;
+}
+
+// Error JSON response
+function json_error($httpCode, $error, $details = []) {
+    send_headers();
+    http_response_code($httpCode);
+    echo json_encode(['ok' => false, 'error' => $error, 'details' => $details]);
+    exit;
+}
+
+// Basic structured logging
+function log_line($endpoint, $latency, $cache) {
+    $ts = date('c');
+    $msg = sprintf('[%s] endpoint=%s latency=%.3fs cache=%s', $ts, $endpoint, $latency, $cache);
+    error_log($msg);
+}

--- a/app/api/error_codes.php
+++ b/app/api/error_codes.php
@@ -1,0 +1,7 @@
+<?php
+// Minimal mapping of Huawei alarm codes to human-readable messages
+return [
+    '1001' => 'Grid loss',
+    '1002' => 'Overvoltage',
+    '1003' => 'Undervoltage',
+];

--- a/app/api/healthz.php
+++ b/app/api/healthz.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/_util.php';
+
+$proxyOk = false;
+$ch = curl_init('https://ifconfig.me');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_NOBODY => true,
+    CURLOPT_PROXY => $CONFIG['MA_PROXY'],
+    CURLOPT_CONNECTTIMEOUT => 5,
+    CURLOPT_TIMEOUT => 10,
+]);
+curl_exec($ch);
+if (!curl_errno($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) > 0) {
+    $proxyOk = true;
+}
+curl_close($ch);
+
+send_headers();
+echo json_encode([
+    'ok' => true,
+    'env' => $CONFIG['APP_ENV'],
+    'proxyReachable' => $proxyOk,
+    'time' => date('c'),
+]);

--- a/app/api/login.php
+++ b/app/api/login.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__ . '/_client.php';
+
+try {
+    fs_login(true);
+    json_ok(['loggedIn' => true]);
+} catch (Exception $e) {
+    json_error(500, 'login_failed');
+}

--- a/app/api/station_alarms.php
+++ b/app/api/station_alarms.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/_client.php';
+require_once __DIR__ . '/_cache.php';
+$ALARM_MAP = require __DIR__ . '/error_codes.php';
+
+$code = $_GET['code'] ?? '';
+$severity = $_GET['severity'] ?? 'all';
+if (!$code) {
+    json_error(400, 'missing_code');
+}
+$key = 'alarms_' . $code . '_' . $severity;
+$start = microtime(true);
+
+if ($cached = cache_get($key)) {
+    log_line('station_alarms', microtime(true) - $start, 'hit');
+    json_ok($cached);
+}
+
+try {
+    $payload = ['stationCodes' => [$code], 'pageNo' => 1, 'pageSize' => 200];
+    $resp = fs_request('POST', '/thirdData/stationAlarmList', $payload);
+    $list = $resp['data']['list'] ?? [];
+    $alarms = [];
+    foreach ($list as $al) {
+        $codeId = $al['alarmId'] ?? '';
+        $alarms[] = [
+            'code' => $codeId,
+            'severity' => strtolower($al['alarmLevel'] ?? ''),
+            'message' => $ALARM_MAP[$codeId] ?? 'Unknown alarm',
+            'deviceName' => $al['devName'] ?? '',
+            'firstSeen' => $al['occurTime'] ?? '',
+            'lastSeen' => $al['recoverTime'] ?? '',
+            'status' => $al['status'] ?? '',
+        ];
+    }
+    if ($severity !== 'all') {
+        $alarms = array_values(array_filter($alarms, function ($a) use ($severity) {
+            return $a['severity'] === strtolower($severity);
+        }));
+    }
+    cache_set($key, $alarms);
+    log_line('station_alarms', microtime(true) - $start, 'miss');
+    json_ok($alarms);
+} catch (Exception $e) {
+    log_line('station_alarms', microtime(true) - $start, 'error');
+    json_error(500, 'fetch_failed');
+}

--- a/app/api/station_devices.php
+++ b/app/api/station_devices.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/_client.php';
+require_once __DIR__ . '/_cache.php';
+
+$code = $_GET['code'] ?? '';
+if (!$code) {
+    json_error(400, 'missing_code');
+}
+$key = 'devices_' . $code;
+$start = microtime(true);
+
+if ($cached = cache_get($key)) {
+    log_line('station_devices', microtime(true) - $start, 'hit');
+    json_ok($cached);
+}
+
+try {
+    $payload = ['stationCode' => $code, 'pageNo' => 1, 'pageSize' => 200];
+    $resp = fs_request('POST', '/thirdData/stationDevList', $payload);
+    $list = $resp['data']['list'] ?? [];
+    $devices = [];
+    foreach ($list as $dev) {
+        $devices[] = [
+            'name' => $dev['devName'] ?? '',
+            'model' => $dev['devTypeName'] ?? '',
+            'serial' => $dev['esn'] ?? '',
+            'status' => $dev['devState'] ?? '',
+            'lastSeen' => $dev['updateTime'] ?? '',
+            'metrics' => ['power' => $dev['power'] ?? null],
+        ];
+    }
+    cache_set($key, $devices);
+    log_line('station_devices', microtime(true) - $start, 'miss');
+    json_ok($devices);
+} catch (Exception $e) {
+    log_line('station_devices', microtime(true) - $start, 'error');
+    json_error(500, 'fetch_failed');
+}

--- a/app/api/station_overview.php
+++ b/app/api/station_overview.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/_client.php';
+require_once __DIR__ . '/_cache.php';
+
+$code = $_GET['code'] ?? '';
+if (!$code) {
+    json_error(400, 'missing_code');
+}
+$key = 'overview_' . $code;
+$start = microtime(true);
+
+if ($cached = cache_get($key)) {
+    log_line('station_overview', microtime(true) - $start, 'hit');
+    json_ok($cached);
+}
+
+try {
+    $payload = ['stationCodes' => [$code]];
+    $resp = fs_request('POST', '/thirdData/stationRealKpi', $payload);
+    $kpi = $resp['data'][0] ?? [];
+    $data = [
+        'currentPower' => $kpi['realTimePower'] ?? null,
+        'todayEnergy' => $kpi['dayPower'] ?? null,
+        'totalEnergy' => $kpi['totalPower'] ?? null,
+        'pr' => $kpi['perpowerRatio'] ?? null,
+    ];
+    cache_set($key, $data);
+    log_line('station_overview', microtime(true) - $start, 'miss');
+    json_ok($data);
+} catch (Exception $e) {
+    log_line('station_overview', microtime(true) - $start, 'error');
+    json_error(500, 'fetch_failed');
+}

--- a/app/api/stations.php
+++ b/app/api/stations.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/_client.php';
+require_once __DIR__ . '/_cache.php';
+
+$pageNo = isset($_GET['pageNo']) ? (int)$_GET['pageNo'] : 1;
+$pageSize = isset($_GET['pageSize']) ? (int)$_GET['pageSize'] : 50;
+$key = "stations_{$pageNo}_{$pageSize}";
+$start = microtime(true);
+
+if ($cached = cache_get($key)) {
+    log_line('stations', microtime(true) - $start, 'hit');
+    json_ok($cached);
+}
+
+try {
+    $payload = ['pageNo' => $pageNo, 'pageSize' => $pageSize];
+    $resp = fs_request('POST', '/thirdData/stationList', $payload);
+    cache_set($key, $resp);
+    log_line('stations', microtime(true) - $start, 'miss');
+    json_ok($resp);
+} catch (Exception $e) {
+    log_line('stations', microtime(true) - $start, 'error');
+    json_error(500, 'fetch_failed');
+}

--- a/app/config/.env.php
+++ b/app/config/.env.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    // FusionSolar base URL
+    'FS_BASE' => 'https://intl.fusionsolar.huawei.com',
+    // Credentials are loaded from environment variables or filled here on the server.
+    'FS_USER' => getenv('FS_USER') ?: '<set-on-server>',
+    'FS_CODE' => getenv('FS_CODE') ?: '<set-on-server>',
+    // Morocco proxy
+    'MA_PROXY' => 'http://154.70.204.15:3128',
+    // Cache TTL in seconds
+    'CACHE_TTL_SECONDS' => 90,
+    // Application environment: prod or dev
+    'APP_ENV' => 'prod',
+    // Allowed origin for CORS
+    'ALLOWED_ORIGIN' => 'https://yourdomain.tld',
+];

--- a/app/public/assets/client-logo.svg
+++ b/app/public/assets/client-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#ccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="16" fill="#333">Client</text>
+</svg>

--- a/app/public/assets/empty-state.svg
+++ b/app/public/assets/empty-state.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80"><rect width="120" height="80" fill="#eee" stroke="#ccc"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#999" font-size="12">Empty</text></svg>

--- a/app/public/assets/styles.css
+++ b/app/public/assets/styles.css
@@ -1,0 +1,60 @@
+:root {
+  --brand-color: #007BFF; /* <CLIENT_BRAND_COLOR_HEX> */
+  --bg-color: #ffffff;
+  --text-color: #333333;
+}
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #eeeeee;
+}
+body {
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: var(--brand-color);
+  color: #fff;
+}
+.logo {
+  height: 40px;
+}
+.container {
+  padding: 1rem;
+}
+.card {
+  background: #f9f9f9;
+  margin: 0.5rem 0;
+  padding: 1rem;
+  border-radius: 4px;
+}
+[data-theme="dark"] .card {
+  background: #2a2a2a;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th, .table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+.table th {
+  background: #eee;
+}
+[data-theme="dark"] .table th {
+  background: #444;
+}
+button.toggle {
+  background: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/app/public/assets/sunq-logo.svg
+++ b/app/public/assets/sunq-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#333" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="16" fill="#fff">SUNQ</text>
+</svg>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Example Client Solar Dashboard</title>
+<link rel="stylesheet" href="assets/styles.css">
+<script src="https://unpkg.com/vue@3"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<div id="app" v-cloak>
+  <header>
+    <div>
+      <img src="assets/client-logo.svg" class="logo" alt="Client logo"> Example Client
+    </div>
+    <div>
+      Built by SUNQ <img src="assets/sunq-logo.svg" class="logo" alt="SUNQ logo">
+      <button class="toggle" @click="toggleTheme">{{ theme==='dark' ? 'Light' : 'Dark' }}</button>
+    </div>
+  </header>
+  <div class="container">
+    <div v-if="error" class="card">{{ error }}</div>
+    <div v-if="view==='stations'">
+      <input type="text" v-model="search" placeholder="Search" aria-label="Search stations">
+      <div v-for="s in filteredStations" :key="s.stationCode" class="card" @click="selectStation(s)" role="button" tabindex="0">
+        <strong>{{ s.stationName }}</strong><br>
+        <small>{{ s.city }}</small>
+      </div>
+    </div>
+    <div v-else>
+      <button @click="view='stations'">&lt; Back</button>
+      <h2>{{ station.stationName }}</h2>
+      <div class="card">Current Power: {{ overview.currentPower ?? 'N/A' }}</div>
+      <div class="card">Today Energy: {{ overview.todayEnergy ?? 'N/A' }}</div>
+      <div class="card">Lifetime Energy: {{ overview.totalEnergy ?? 'N/A' }}</div>
+      <div v-if="overview.pr" class="card">PR: {{ overview.pr }}</div>
+      <div class="card">
+        <canvas id="powerChart" height="100"></canvas>
+      </div>
+      <h3>Devices</h3>
+      <table class="table">
+        <thead><tr><th>Device</th><th>Model</th><th>Serial</th><th>Status</th><th>Last Seen</th><th>Power</th></tr></thead>
+        <tbody>
+          <tr v-for="d in devices" :key="d.serial">
+            <td>{{ d.name }}</td>
+            <td>{{ d.model }}</td>
+            <td>{{ d.serial }}</td>
+            <td>{{ d.status }}</td>
+            <td>{{ d.lastSeen }}</td>
+            <td>{{ d.metrics.power ?? '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Alarms</h3>
+      <div>
+        <button v-for="sev in severities" :key="sev" @click="alarmSeverity=sev" :class="{active:alarmSeverity===sev}" class="toggle" style="margin-right:4px;">{{ sev }}</button>
+      </div>
+      <table class="table">
+        <thead><tr><th>Code</th><th>Severity</th><th>Message</th><th>Device</th><th>First</th><th>Last</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr v-for="a in filteredAlarms" :key="a.code+a.deviceName">
+            <td>{{ a.code }}</td>
+            <td>{{ a.severity }}</td>
+            <td>{{ a.message }}</td>
+            <td>{{ a.deviceName }}</td>
+            <td>{{ a.firstSeen }}</td>
+            <td>{{ a.lastSeen }}</td>
+            <td>{{ a.status }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Last updated {{ lastUpdated }}</p>
+    </div>
+  </div>
+</div>
+
+<script>
+const CO2_FACTOR_KG_PER_KWH = 0.60;
+const TREES_PER_TON_CO2 = 45;
+const KWH_PER_HOME_PER_DAY = 30;
+
+const app = Vue.createApp({
+  data() {
+    return {
+      stations: [],
+      view: 'stations',
+      station: null,
+      overview: {},
+      devices: [],
+      alarms: [],
+      alarmSeverity: 'all',
+      severities: ['all','critical','major','minor','info'],
+      error: null,
+      search: '',
+      lastUpdated: null,
+      theme: localStorage.getItem('theme') || 'light'
+    }
+  },
+  computed: {
+    filteredStations() {
+      const q = this.search.toLowerCase();
+      return this.stations.filter(s => s.stationName.toLowerCase().includes(q));
+    },
+    filteredAlarms() {
+      if (this.alarmSeverity === 'all') return this.alarms;
+      return this.alarms.filter(a => a.severity === this.alarmSeverity);
+    }
+  },
+  mounted() {
+    document.documentElement.setAttribute('data-theme', this.theme);
+    this.fetchStations();
+    setInterval(() => {
+      if (this.view === 'detail' && this.station) {
+        this.loadDetail();
+      }
+    }, 60000);
+  },
+    methods: {
+      toggleTheme() {
+        this.theme = this.theme === "dark" ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", this.theme);
+        localStorage.setItem("theme", this.theme);
+      },
+      fetchStations() {
+        fetch("../api/stations.php").then(r => r.json()).then(j => {
+          if (j.ok) {
+            this.stations = j.data.data || j.data;
+          } else {
+            this.error = "Failed to load stations";
+          }
+        }).catch(() => this.error = "Data service unavailable.");
+      },
+      selectStation(s) {
+        this.station = s;
+        this.view = "detail";
+        this.loadDetail();
+      },
+      loadDetail() {
+        this.fetchOverview();
+        this.fetchDevices();
+        this.fetchAlarms();
+        this.renderChart();
+        this.lastUpdated = new Date().toLocaleTimeString();
+      },
+      fetchOverview() {
+        fetch(`../api/station_overview.php?code=${this.station.stationCode}`).then(r=>r.json()).then(j=>{if(j.ok) this.overview=j.data;});
+      },
+      fetchDevices() {
+        fetch(`../api/station_devices.php?code=${this.station.stationCode}`).then(r=>r.json()).then(j=>{if(j.ok) this.devices=j.data;});
+      },
+      fetchAlarms() {
+        fetch(`../api/station_alarms.php?code=${this.station.stationCode}&severity=${this.alarmSeverity}`).then(r=>r.json()).then(j=>{if(j.ok) this.alarms=j.data;});
+      },
+      renderChart() {
+        const ctx = document.getElementById("powerChart").getContext("2d");
+        if (this.chart) this.chart.destroy();
+        this.chart = new Chart(ctx, {
+          type: "line",
+          data: { labels: [], datasets: [{ label: "Power", data: [] }] }
+        });
+      }
+    }
+});
+
+app.mount('#app');
+</script>
+</body>
+</html>

--- a/app/tools/check_proxy.php
+++ b/app/tools/check_proxy.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../api/_util.php';
+
+$ch = curl_init('https://ifconfig.me');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_PROXY => $CONFIG['MA_PROXY'],
+    CURLOPT_TIMEOUT => 10,
+]);
+$res = curl_exec($ch);
+$ok = (!curl_errno($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) == 200);
+curl_close($ch);
+
+header('Content-Type: text/plain');
+if ($ok) {
+    echo "Proxy OK: $res";
+} else {
+    echo "Proxy FAILED";
+}


### PR DESCRIPTION
## Summary
- add PHP cURL client with proxy, cookie jar and XSRF token handling
- expose cached API endpoints for stations, KPIs, devices, alarms and health checks
- include Vue 3 dashboard with light/dark mode and polling
- replace binary logo assets with SVG placeholders

## Testing
- `find app -name '*.php' -not -path '*/storage/*' -print0 | xargs -0 -n1 php -l`
- `php app/api/healthz.php`


------
https://chatgpt.com/codex/tasks/task_b_68a84cf051f883248467110d8794710c