### PR TITLE
harden FusionSolar PHP proxy and SPA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+FS_BASE=https://intl.fusionsolar.huawei.com
+FS_USER=changeme
+FS_CODE=changeme
+MA_PROXY=http://154.70.204.15:3128
+CACHE_TTL_SECONDS=90
+ALLOWED_ORIGIN=
+APP_VERSION=dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+- replace PHP utilities with env-based configuration and structured logging
+- add caching layer and robust FusionSolar client with proxy, retries and cookie management
+- expose clean REST endpoints via `/api` front controller
+- improve health check and CORS handling
+- refresh frontend to use new API paths and show empty states
+- add `.env.example` and update documentation

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# SUNQ Fusion Solar API
+
+PHP backend proxy for Huawei FusionSolar NB API with simple frontend.
+
+## Quick start
+
+```bash
+cp .env.example .env
+# edit .env with real credentials (do not commit)
+php -S localhost:8080 -t app app/api/index.php
+```
+
+Visit `http://localhost:8080/public/` in your browser.
+
+## Required environment variables
+
+- `FS_BASE` – FusionSolar NB base URL
+- `FS_USER` – login user (from FusionSolar)
+- `FS_CODE` – login system code
+- `MA_PROXY` – HTTP proxy (e.g. `http://154.70.204.15:3128`)
+- `CACHE_TTL_SECONDS` – cache time for NB responses
+- `ALLOWED_ORIGIN` – optional exact origin for CORS; leave blank for same-origin
+- `APP_VERSION` – version string exposed by `/healthz`
+
+Credentials are loaded from environment at runtime and are not stored in this repo. Rotate them by updating your environment and restarting the service.
+
+## Example requests
+
+```bash
+curl -H 'X-Request-Id: demo' http://localhost:8080/api/stations
+curl http://localhost:8080/api/stations/STATION_CODE/overview
+curl http://localhost:8080/api/stations/STATION_CODE/devices
+curl http://localhost:8080/api/stations/STATION_CODE/alarms?severity=major
+curl http://localhost:8080/api/healthz
+```
+
+## Troubleshooting
+
+- To confirm the proxy is used, run `php app/tools/check_proxy.php`.
+- Upstream failures return JSON:
+  ```json
+  {"error":{"code":"UPSTREAM_ERROR","status":502,"message":"...","req_id":"..."}}
+  ```
+- `/healthz` never contacts FusionSolar and reports whether the proxy is reachable.

--- a/app/api/_util.php
+++ b/app/api/_util.php
@@ -1,34 +1,66 @@
 <?php
-// Common utilities: config loader, JSON helpers, logging, CORS
+// Utility helpers: config loader, responses, logging, IDs
 
-$CONFIG = require __DIR__ . '/../config/.env.php';
+function env($key, $default = null) {
+    $val = getenv($key);
+    return $val !== false ? $val : $default;
+}
 
-// Send CORS and JSON headers
+$CONFIG = [
+    'FS_BASE' => rtrim(env('FS_BASE', 'https://intl.fusionsolar.huawei.com'), '/'),
+    'FS_USER' => env('FS_USER'),
+    'FS_CODE' => env('FS_CODE'),
+    'MA_PROXY' => env('MA_PROXY'),
+    'CACHE_TTL_SECONDS' => (int)env('CACHE_TTL_SECONDS', 90),
+    'ALLOWED_ORIGIN' => env('ALLOWED_ORIGIN'),
+    'APP_VERSION' => env('APP_VERSION', 'dev'),
+];
+
 function send_headers() {
     global $CONFIG;
     header('Content-Type: application/json');
-    header('Access-Control-Allow-Origin: ' . $CONFIG['ALLOWED_ORIGIN']);
-    header('Vary: Origin');
+    if (!empty($CONFIG['ALLOWED_ORIGIN'])) {
+        header('Access-Control-Allow-Origin: ' . $CONFIG['ALLOWED_ORIGIN']);
+        header('Vary: Origin');
+    }
 }
 
-// Successful JSON response
+function uuidv4() {
+    $data = random_bytes(16);
+    $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+    $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+    return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+}
+
+function get_req_id() {
+    static $id = null;
+    if ($id) return $id;
+    $id = $_SERVER['HTTP_X_REQUEST_ID'] ?? uuidv4();
+    return $id;
+}
+
 function json_ok($data) {
     send_headers();
-    echo json_encode(['ok' => true, 'data' => $data]);
+    echo json_encode($data);
     exit;
 }
 
-// Error JSON response
-function json_error($httpCode, $error, $details = []) {
+function json_error($status, $code, $message) {
     send_headers();
-    http_response_code($httpCode);
-    echo json_encode(['ok' => false, 'error' => $error, 'details' => $details]);
+    http_response_code($status);
+    echo json_encode([
+        'error' => [
+            'code' => $code,
+            'status' => $status,
+            'message' => $message,
+            'req_id' => get_req_id(),
+        ]
+    ]);
     exit;
 }
 
-// Basic structured logging
-function log_line($endpoint, $latency, $cache) {
-    $ts = date('c');
-    $msg = sprintf('[%s] endpoint=%s latency=%.3fs cache=%s', $ts, $endpoint, $latency, $cache);
-    error_log($msg);
+function log_json($fields) {
+    $fields['ts'] = date('c');
+    error_log(json_encode($fields));
 }
+?>

--- a/app/api/healthz.php
+++ b/app/api/healthz.php
@@ -19,7 +19,8 @@ curl_close($ch);
 send_headers();
 echo json_encode([
     'ok' => true,
-    'env' => $CONFIG['APP_ENV'],
+    'version' => $CONFIG['APP_VERSION'],
     'proxyReachable' => $proxyOk,
-    'time' => date('c'),
+    'time' => gmdate('c'),
 ]);
+?>

--- a/app/api/index.php
+++ b/app/api/index.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/_util.php';
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+if (strpos($uri, '/api/') === 0) {
+    $uri = substr($uri, 4);
+}
+$segments = array_values(array_filter(explode('/', $uri)));
+
+if (empty($segments)) {
+    json_error(404, 'NOT_FOUND', 'Endpoint not found');
+}
+
+switch ($segments[0]) {
+    case 'healthz':
+        require __DIR__ . '/healthz.php';
+        break;
+    case 'stations':
+        if (count($segments) === 1) {
+            require __DIR__ . '/stations.php';
+            break;
+        }
+        $_GET['code'] = $segments[1];
+        $sub = $segments[2] ?? null;
+        if ($sub === 'overview') {
+            require __DIR__ . '/station_overview.php';
+        } elseif ($sub === 'devices') {
+            require __DIR__ . '/station_devices.php';
+        } elseif ($sub === 'alarms') {
+            require __DIR__ . '/station_alarms.php';
+        } else {
+            json_error(404, 'NOT_FOUND', 'Endpoint not found');
+        }
+        break;
+    default:
+        json_error(404, 'NOT_FOUND', 'Endpoint not found');
+}
+?>

--- a/app/api/station_overview.php
+++ b/app/api/station_overview.php
@@ -1,33 +1,24 @@
 <?php
 require_once __DIR__ . '/_client.php';
-require_once __DIR__ . '/_cache.php';
 
 $code = $_GET['code'] ?? '';
 if (!$code) {
-    json_error(400, 'missing_code');
-}
-$key = 'overview_' . $code;
-$start = microtime(true);
-
-if ($cached = cache_get($key)) {
-    log_line('station_overview', microtime(true) - $start, 'hit');
-    json_ok($cached);
+    json_error(400, 'BAD_REQUEST', 'missing code');
 }
 
 try {
-    $payload = ['stationCodes' => [$code]];
-    $resp = fs_request('POST', '/thirdData/stationRealKpi', $payload);
+    $body = ['stationCodes' => [$code]];
+    $resp = fs_request('POST', '/thirdData/stationRealKpi', [], $body);
     $kpi = $resp['data'][0] ?? [];
     $data = [
         'currentPower' => $kpi['realTimePower'] ?? null,
         'todayEnergy' => $kpi['dayPower'] ?? null,
         'totalEnergy' => $kpi['totalPower'] ?? null,
-        'pr' => $kpi['perpowerRatio'] ?? null,
+        'perpowerRatio' => $kpi['perpowerRatio'] ?? null,
     ];
-    cache_set($key, $data);
-    log_line('station_overview', microtime(true) - $start, 'miss');
     json_ok($data);
 } catch (Exception $e) {
-    log_line('station_overview', microtime(true) - $start, 'error');
-    json_error(500, 'fetch_failed');
+    $status = $e->getCode() >= 400 ? $e->getCode() : 502;
+    json_error($status, 'UPSTREAM_ERROR', 'overview fetch failed');
 }
+?>

--- a/app/api/stations.php
+++ b/app/api/stations.php
@@ -1,24 +1,29 @@
 <?php
 require_once __DIR__ . '/_client.php';
-require_once __DIR__ . '/_cache.php';
 
 $pageNo = isset($_GET['pageNo']) ? (int)$_GET['pageNo'] : 1;
 $pageSize = isset($_GET['pageSize']) ? (int)$_GET['pageSize'] : 50;
-$key = "stations_{$pageNo}_{$pageSize}";
-$start = microtime(true);
-
-if ($cached = cache_get($key)) {
-    log_line('stations', microtime(true) - $start, 'hit');
-    json_ok($cached);
-}
+if ($pageNo < 1) $pageNo = 1;
+if ($pageSize < 1) $pageSize = 1;
+$pageNo = min($pageNo, 100);
+$pageSize = min($pageSize, 200);
 
 try {
-    $payload = ['pageNo' => $pageNo, 'pageSize' => $pageSize];
-    $resp = fs_request('POST', '/thirdData/stationList', $payload);
-    cache_set($key, $resp);
-    log_line('stations', microtime(true) - $start, 'miss');
-    json_ok($resp);
+    $body = ['pageNo' => $pageNo, 'pageSize' => $pageSize];
+    $resp = fs_request('POST', '/thirdData/stationList', [], $body);
+    $list = $resp['data']['list'] ?? $resp['data'] ?? [];
+    $stations = [];
+    foreach ($list as $s) {
+        $stations[] = [
+            'code' => $s['stationCode'] ?? $s['id'] ?? '',
+            'name' => $s['stationName'] ?? '',
+            'capacity' => $s['capacity'] ?? null,
+            'city' => $s['city'] ?? '',
+        ];
+    }
+    json_ok($stations);
 } catch (Exception $e) {
-    log_line('stations', microtime(true) - $start, 'error');
-    json_error(500, 'fetch_failed');
+    $status = $e->getCode() >= 400 ? $e->getCode() : 502;
+    json_error($status, 'UPSTREAM_ERROR', 'station list failed');
 }
+?>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Example Client Solar Dashboard</title>
 <link rel="stylesheet" href="assets/styles.css">
+<script>window.API_BASE='/api';</script>
 <script src="https://unpkg.com/vue@3"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
@@ -23,63 +24,60 @@
     <div v-if="error" class="card">{{ error }}</div>
     <div v-if="view==='stations'">
       <input type="text" v-model="search" placeholder="Search" aria-label="Search stations">
-      <div v-for="s in filteredStations" :key="s.stationCode" class="card" @click="selectStation(s)" role="button" tabindex="0">
-        <strong>{{ s.stationName }}</strong><br>
+      <div v-if="filteredStations.length===0" class="card">Empty</div>
+      <div v-for="s in filteredStations" :key="s.code" class="card" @click="selectStation(s)" role="button" tabindex="0">
+        <strong>{{ s.name }}</strong><br>
         <small>{{ s.city }}</small>
       </div>
     </div>
     <div v-else>
       <button @click="view='stations'">&lt; Back</button>
-      <h2>{{ station.stationName }}</h2>
+      <h2>{{ station.name }}</h2>
       <div class="card">Current Power: {{ overview.currentPower ?? 'N/A' }}</div>
       <div class="card">Today Energy: {{ overview.todayEnergy ?? 'N/A' }}</div>
-      <div class="card">Lifetime Energy: {{ overview.totalEnergy ?? 'N/A' }}</div>
-      <div v-if="overview.pr" class="card">PR: {{ overview.pr }}</div>
+      <div class="card">Total Energy: {{ overview.totalEnergy ?? 'N/A' }}</div>
+      <div v-if="overview.perpowerRatio" class="card">PR: {{ overview.perpowerRatio }}</div>
       <div class="card">
         <canvas id="powerChart" height="100"></canvas>
       </div>
       <h3>Devices</h3>
-      <table class="table">
-        <thead><tr><th>Device</th><th>Model</th><th>Serial</th><th>Status</th><th>Last Seen</th><th>Power</th></tr></thead>
+      <table class="table" v-if="devices.length">
+        <thead><tr><th>ID</th><th>Type</th><th>Model</th><th>Status</th><th>Rated Power</th><th>SN</th></tr></thead>
         <tbody>
-          <tr v-for="d in devices" :key="d.serial">
-            <td>{{ d.name }}</td>
+          <tr v-for="d in devices" :key="d.id">
+            <td>{{ d.id }}</td>
+            <td>{{ d.type }}</td>
             <td>{{ d.model }}</td>
-            <td>{{ d.serial }}</td>
             <td>{{ d.status }}</td>
-            <td>{{ d.lastSeen }}</td>
-            <td>{{ d.metrics.power ?? '-' }}</td>
+            <td>{{ d.ratedPower ?? '-' }}</td>
+            <td>{{ d.sn ?? '-' }}</td>
           </tr>
         </tbody>
       </table>
+      <p v-else>Empty</p>
       <h3>Alarms</h3>
       <div>
-        <button v-for="sev in severities" :key="sev" @click="alarmSeverity=sev" :class="{active:alarmSeverity===sev}" class="toggle" style="margin-right:4px;">{{ sev }}</button>
+        <button v-for="sev in severities" :key="sev" @click="alarmSeverity=sev;fetchAlarms();" :class="{active:alarmSeverity===sev}" class="toggle" style="margin-right:4px;">{{ sev }}</button>
       </div>
-      <table class="table">
-        <thead><tr><th>Code</th><th>Severity</th><th>Message</th><th>Device</th><th>First</th><th>Last</th><th>Status</th></tr></thead>
+      <table class="table" v-if="filteredAlarms.length">
+        <thead><tr><th>ID</th><th>Device</th><th>Level</th><th>Message</th><th>Start</th></tr></thead>
         <tbody>
-          <tr v-for="a in filteredAlarms" :key="a.code+a.deviceName">
-            <td>{{ a.code }}</td>
-            <td>{{ a.severity }}</td>
+          <tr v-for="a in filteredAlarms" :key="a.id+a.deviceId">
+            <td>{{ a.id }}</td>
+            <td>{{ a.deviceId }}</td>
+            <td>{{ a.level }}</td>
             <td>{{ a.message }}</td>
-            <td>{{ a.deviceName }}</td>
-            <td>{{ a.firstSeen }}</td>
-            <td>{{ a.lastSeen }}</td>
-            <td>{{ a.status }}</td>
+            <td>{{ a.startTime }}</td>
           </tr>
         </tbody>
       </table>
+      <p v-else>Empty</p>
       <p>Last updated {{ lastUpdated }}</p>
     </div>
   </div>
 </div>
 
 <script>
-const CO2_FACTOR_KG_PER_KWH = 0.60;
-const TREES_PER_TON_CO2 = 45;
-const KWH_PER_HOME_PER_DAY = 30;
-
 const app = Vue.createApp({
   data() {
     return {
@@ -100,11 +98,11 @@ const app = Vue.createApp({
   computed: {
     filteredStations() {
       const q = this.search.toLowerCase();
-      return this.stations.filter(s => s.stationName.toLowerCase().includes(q));
+      return this.stations.filter(s => s.name.toLowerCase().includes(q));
     },
     filteredAlarms() {
       if (this.alarmSeverity === 'all') return this.alarms;
-      return this.alarms.filter(a => a.severity === this.alarmSeverity);
+      return this.alarms.filter(a => a.level === this.alarmSeverity);
     }
   },
   mounted() {
@@ -112,55 +110,54 @@ const app = Vue.createApp({
     this.fetchStations();
     setInterval(() => {
       if (this.view === 'detail' && this.station) {
-        this.loadDetail();
-      }
-    }, 60000);
-  },
-    methods: {
-      toggleTheme() {
-        this.theme = this.theme === "dark" ? "light" : "dark";
-        document.documentElement.setAttribute("data-theme", this.theme);
-        localStorage.setItem("theme", this.theme);
-      },
-      fetchStations() {
-        fetch("../api/stations.php").then(r => r.json()).then(j => {
-          if (j.ok) {
-            this.stations = j.data.data || j.data;
-          } else {
-            this.error = "Failed to load stations";
-          }
-        }).catch(() => this.error = "Data service unavailable.");
-      },
-      selectStation(s) {
-        this.station = s;
-        this.view = "detail";
-        this.loadDetail();
-      },
-      loadDetail() {
         this.fetchOverview();
         this.fetchDevices();
         this.fetchAlarms();
-        this.renderChart();
         this.lastUpdated = new Date().toLocaleTimeString();
-      },
-      fetchOverview() {
-        fetch(`../api/station_overview.php?code=${this.station.stationCode}`).then(r=>r.json()).then(j=>{if(j.ok) this.overview=j.data;});
-      },
-      fetchDevices() {
-        fetch(`../api/station_devices.php?code=${this.station.stationCode}`).then(r=>r.json()).then(j=>{if(j.ok) this.devices=j.data;});
-      },
-      fetchAlarms() {
-        fetch(`../api/station_alarms.php?code=${this.station.stationCode}&severity=${this.alarmSeverity}`).then(r=>r.json()).then(j=>{if(j.ok) this.alarms=j.data;});
-      },
-      renderChart() {
-        const ctx = document.getElementById("powerChart").getContext("2d");
-        if (this.chart) this.chart.destroy();
-        this.chart = new Chart(ctx, {
-          type: "line",
-          data: { labels: [], datasets: [{ label: "Power", data: [] }] }
-        });
       }
+    }, 60000);
+  },
+  methods: {
+    toggleTheme() {
+      this.theme = this.theme === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', this.theme);
+      localStorage.setItem('theme', this.theme);
+    },
+    fetchStations() {
+      fetch(`${API_BASE}/stations`).then(r => r.json()).then(j => {
+        if (!j.error) {
+          this.stations = j;
+        } else {
+          this.error = 'Failed to load stations';
+        }
+      }).catch(() => this.error = 'Data service unavailable.');
+    },
+    selectStation(s) {
+      this.station = s;
+      this.view = 'detail';
+      this.fetchOverview();
+      this.fetchDevices();
+      this.fetchAlarms();
+      this.lastUpdated = new Date().toLocaleTimeString();
+    },
+    fetchOverview() {
+      fetch(`${API_BASE}/stations/${this.station.code}/overview`).then(r=>r.json()).then(j=>{ if(!j.error) this.overview=j; });
+    },
+    fetchDevices() {
+      fetch(`${API_BASE}/stations/${this.station.code}/devices`).then(r=>r.json()).then(j=>{ if(!j.error) this.devices=j; });
+    },
+    fetchAlarms() {
+      fetch(`${API_BASE}/stations/${this.station.code}/alarms?severity=${this.alarmSeverity}`).then(r=>r.json()).then(j=>{ if(!j.error) this.alarms=j; });
+    },
+    renderChart() {
+      const ctx = document.getElementById('powerChart').getContext('2d');
+      if (this.chart) this.chart.destroy();
+      this.chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Power', data: [] }] }
+      });
     }
+  }
 });
 
 app.mount('#app');

--- a/app/tools/integration_test.sh
+++ b/app/tools/integration_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+PORT_NB=9001
+PORT_API=9002
+php -S 127.0.0.1:$PORT_NB app/tools/mock_nb.php >/tmp/mock_nb.log 2>&1 &
+NB_PID=$!
+sleep 1
+export FS_BASE="http://127.0.0.1:$PORT_NB"
+export FS_USER=user
+export FS_CODE=code
+export MA_PROXY=
+export CACHE_TTL_SECONDS=90
+export APP_VERSION=test
+php -S 127.0.0.1:$PORT_API -t app app/api/index.php >/tmp/api.log 2>&1 &
+API_PID=$!
+sleep 1
+first=$(curl -w '%{time_total}' -s http://127.0.0.1:$PORT_API/api/stations -o /tmp/first.json)
+second=$(curl -w '%{time_total}' -s http://127.0.0.1:$PORT_API/api/stations -o /tmp/second.json)
+cat /tmp/first.json
+cat /tmp/second.json
+kill $API_PID $NB_PID
+python3 - <<PY
+import sys
+f=float("$first"); s=float("$second");
+print('first',f,'second',s)
+assert s<=f
+PY

--- a/app/tools/mock_nb.php
+++ b/app/tools/mock_nb.php
@@ -1,0 +1,16 @@
+<?php
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+header('Content-Type: application/json');
+if ($path === '/thirdData/login') {
+    header('Set-Cookie: XSRF-TOKEN=mock; Path=/');
+    echo json_encode(['data' => true]);
+    return;
+}
+if ($path === '/thirdData/stationList') {
+    echo json_encode(['data' => ['list' => [
+        ['stationCode'=>'001','stationName'=>'Mock Station','capacity'=>10,'city'=>'Rabat']
+    ]]]);
+    return;
+}
+http_response_code(404);
+?>


### PR DESCRIPTION
## Summary
- add env-driven config, structured logging, and centralized router
- harden FusionSolar client with proxy support, caching, retries, and structured errors
- refresh SPA to use new `/api` endpoints, show empty states, and poll data

## Testing
- `php -l app/api/_util.php app/api/_cache.php app/api/_client.php app/api/index.php app/api/stations.php app/api/station_overview.php app/api/station_devices.php app/api/station_alarms.php app/api/healthz.php app/tools/mock_nb.php`
- `app/tools/integration_test.sh`

------
https://chatgpt.com/codex/tasks/task_b_68a85afacec08324bdef9983fb8ab72c