### PR TITLE
Add Docker configuration for PHP app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.git
+.gitignore
+vendor
+app/storage
+app/config
+tests
+*.md
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM php:8.3-cli-alpine
+
+# Install system dependencies and Composer
+RUN apk add --no-cache git curl unzip && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Set work directory
+WORKDIR /app
+
+# Copy composer definition and install PHP dependencies
+COPY composer.json ./
+RUN composer install --no-dev --prefer-dist --no-progress --no-interaction
+
+# Copy project files
+COPY . .
+
+# Ensure cache directory exists
+RUN mkdir -p app/storage/cache
+
+EXPOSE 8096
+
+CMD ["php", "-S", "0.0.0.0:8096", "-t", "app", "app/api/index.php"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,17 @@ COPY . .
 # Ensure cache directory exists
 RUN mkdir -p app/storage/cache
 
+# Default configuration values (override at runtime with -e/--env)
+ENV FS_BASE="https://intl.fusionsolar.huawei.com" \
+    FS_USER="changeme" \
+    FS_CODE="changeme" \
+    MA_PROXY="http://154.70.204.15:3128" \
+    CACHE_TTL_SECONDS="90" \
+    CACHE_BACKEND="file" \
+    FRONTEND_ORIGIN="" \
+    APP_VERSION="dev" \
+    RATE_LIMIT_PER_MINUTE="0"
+
 EXPOSE 8096
 
 CMD ["php", "-S", "0.0.0.0:8096", "-t", "app", "app/api/index.php"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PHP backend proxy for Huawei FusionSolar NB API with session handling, caching a
 cp .env.example .env
 # edit .env with real credentials (do not commit)
 composer install
-php -S localhost:8080 -t app app/api/index.php
+php -S localhost:8096 -t app app/api/index.php
 ```
 
 ## Public endpoints
@@ -38,11 +38,11 @@ All outbound HTTP requests go through `MA_PROXY`. The backend logs in to FusionS
 ## Example requests
 
 ```bash
-curl http://localhost:8080/api/stations?page=1
-curl http://localhost:8080/api/stations/STATION_CODE/overview
-curl http://localhost:8080/api/stations/STATION_CODE/devices
-curl http://localhost:8080/api/stations/STATION_CODE/alarms?levels=1,2
-curl http://localhost:8080/api/healthz
+curl http://localhost:8096/api/stations?page=1
+curl http://localhost:8096/api/stations/STATION_CODE/overview
+curl http://localhost:8096/api/stations/STATION_CODE/devices
+curl http://localhost:8096/api/stations/STATION_CODE/alarms?levels=1,2
+curl http://localhost:8096/api/healthz
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -5,8 +5,22 @@ PHP backend proxy for Huawei FusionSolar NB API with session handling, caching a
 ## Quick start
 
 ```bash
-cp .env.example .env
-# edit .env with real credentials (do not commit)
+docker build -t fusion-solar-api .
+docker run -p 8096:8096 \
+  -e FS_BASE=https://intl.fusionsolar.huawei.com \
+  -e FS_USER=your_user \
+  -e FS_CODE=your_code \
+  -e MA_PROXY=http://154.70.204.15:3128 \
+  fusion-solar-api
+```
+
+For local development without Docker:
+
+```bash
+export FS_BASE=https://intl.fusionsolar.huawei.com
+export FS_USER=your_user
+export FS_CODE=your_code
+export MA_PROXY=http://154.70.204.15:3128
 composer install
 php -S localhost:8096 -t app app/api/index.php
 ```

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Simple smoke test to verify endpoints when the server is running.
 set -e
-BASE_URL=${BASE_URL:-http://localhost:8080}
+BASE_URL=${BASE_URL:-http://localhost:8096}
 
 echo "GET /api/healthz"
 curl -s "$BASE_URL/api/healthz" || exit 1


### PR DESCRIPTION
## Summary
- containerize PHP backend with lightweight Dockerfile and Composer install
- keep Docker image small via `.dockerignore`
- expose PHP app on port 8096 and update docs and smoke test accordingly

## Testing
- `php -l app/api/index.php`
- `composer install --no-dev --prefer-dist --no-progress --no-interaction` *(failed: CONNECT tunnel failed, response 403)*
- `./tests/smoke.sh` *(failed: Failed opening required '/workspace/SUNQ-Fusion-Solar-API/app/api/../../vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_b_68aa1922ceb08324a76cbaf412a8f873