### PR TITLE
Allow static assets to bypass API router

### DIFF
--- a/app/api/index.php
+++ b/app/api/index.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
+$staticFile = __DIR__ . '/../' . ltrim($uri, '/');
+if ($uri !== '/' && file_exists($staticFile)) {
+    return false;
+}
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/_util.php';
 handle_preflight_and_headers();
@@ -19,7 +25,6 @@ if (!$missingEnv) {
     $client = new FusionSolarClient($CONFIG, $logger);
 }
 
-$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
 // deny direct access to storage directory
 if (preg_match('#^/storage(/|$)#', $uri)) {
     http_response_code(404);


### PR DESCRIPTION
## Summary
- Early exit in API router when request maps to existing file so web server can serve `public` assets directly

## Testing
- `curl -i http://localhost:8096/public/`
- `./tests/smoke.sh` *(fails: Failed opening required '/workspace/SUNQ-Fusion-Solar-API/app/api/../../vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68aa60bc24ec8324b806e733fc538243